### PR TITLE
add cc email

### DIFF
--- a/tests/submissions/test_fields.py
+++ b/tests/submissions/test_fields.py
@@ -53,7 +53,6 @@ def test_to_internal_value_invalid_email(input_value):
     field = SemicolonSeparatedEmailField()
     with pytest.raises(ValidationError) as excinfo:
         field.to_internal_value(input_value)
-    print("DUPA", str(excinfo.value))
     assert "Enter a valid email address" in str(excinfo.value)
 
 

--- a/tests/submissions/test_fields.py
+++ b/tests/submissions/test_fields.py
@@ -1,0 +1,91 @@
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from web_forms.submissions.api.fields import SemicolonSeparatedEmailField
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output",
+    [
+        (
+            "test1@example.com;test2@example.com",
+            ["test1@example.com", "test2@example.com"],
+        ),
+        (
+            " test1@example.com ; test2@example.com ",
+            ["test1@example.com", "test2@example.com"],
+        ),
+        (
+            "test1@example.com;;test2@example.com",
+            ["test1@example.com", "test2@example.com"],
+        ),
+        ("test1@example.com;", ["test1@example.com"]),
+        ("", []),
+    ],
+)
+def test_to_internal_value_valid(input_value, expected_output):
+    field = SemicolonSeparatedEmailField()
+    assert field.to_internal_value(input_value) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        (12345),
+        (["test@example.com"]),
+    ],
+)
+def test_to_internal_value_invalid_type(input_value):
+    field = SemicolonSeparatedEmailField()
+    with pytest.raises(ValidationError) as excinfo:
+        field.to_internal_value(input_value)
+    assert "This field must be a string." in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        ("test1@example.com;invalid-email"),
+        ("invalid-email"),
+    ],
+)
+def test_to_internal_value_invalid_email(input_value):
+    field = SemicolonSeparatedEmailField()
+    with pytest.raises(ValidationError) as excinfo:
+        field.to_internal_value(input_value)
+    print("DUPA", str(excinfo.value))
+    assert "Enter a valid email address" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output",
+    [
+        (
+            ["test1@example.com", "test2@example.com"],
+            "test1@example.com;test2@example.com",
+        ),
+        (
+            [" test1@example.com ", " test2@example.com "],
+            "test1@example.com;test2@example.com",
+        ),
+        (["test1@example.com"], "test1@example.com"),
+        ([], ""),
+    ],
+)
+def test_to_representation_valid(input_value, expected_output):
+    field = SemicolonSeparatedEmailField()
+    assert field.to_representation(input_value) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    [
+        ("test1@example.com;test2@example.com"),
+        (12345),
+    ],
+)
+def test_to_representation_invalid_type(input_value):
+    field = SemicolonSeparatedEmailField()
+    with pytest.raises(ValidationError) as excinfo:
+        field.to_representation(input_value)
+    assert "This field must be a list." in str(excinfo.value)

--- a/tests/submissions/test_views.py
+++ b/tests/submissions/test_views.py
@@ -55,6 +55,7 @@ def test_submission_view_with_extra_fields(api_client, access_key):
         "subject": "Custom Subject",
         "reply_to": "custom@example.com",
         "from_name": "Jeff",
+        "cc_emails": "partner@example.com;accounts@example.com",
     }
     response = api_client.post(url, data, format="multipart")
 

--- a/web_forms/submissions/api/fields.py
+++ b/web_forms/submissions/api/fields.py
@@ -4,17 +4,20 @@ from rest_framework import serializers
 class SemicolonSeparatedEmailField(serializers.Field):
     def to_internal_value(self, data):
         if not isinstance(data, str):
-            raise serializers.ValidationError("This field must be a string.")
+            error_message = "This field must be a string."
+            raise serializers.ValidationError(error_message)
 
         email_list = [email.strip() for email in data.split(";") if email.strip()]
 
         for email in email_list:
             if not serializers.EmailField().run_validation(email):
-                raise serializers.ValidationError(f"Invalid email address: {email}")
+                error_message = f"Invalid email address: {email}"
+                raise serializers.ValidationError(error_message)
 
         return email_list
 
     def to_representation(self, value):
         if not isinstance(value, list):
-            raise serializers.ValidationError("This field must be a list.")
+            error_message = "This field must be a list."
+            raise serializers.ValidationError(error_message)
         return ";".join([x.strip() for x in value])

--- a/web_forms/submissions/api/fields.py
+++ b/web_forms/submissions/api/fields.py
@@ -1,0 +1,20 @@
+from rest_framework import serializers
+
+
+class SemicolonSeparatedEmailField(serializers.Field):
+    def to_internal_value(self, data):
+        if not isinstance(data, str):
+            raise serializers.ValidationError("This field must be a string.")
+
+        email_list = [email.strip() for email in data.split(";") if email.strip()]
+
+        for email in email_list:
+            if not serializers.EmailField().run_validation(email):
+                raise serializers.ValidationError(f"Invalid email address: {email}")
+
+        return email_list
+
+    def to_representation(self, value):
+        if not isinstance(value, list):
+            raise serializers.ValidationError("This field must be a list.")
+        return ";".join([x.strip() for x in value])

--- a/web_forms/submissions/api/serializers.py
+++ b/web_forms/submissions/api/serializers.py
@@ -5,12 +5,15 @@ from web_forms.access_keys.models import AccessKey
 from web_forms.submissions.utils.spam_detection import is_spam
 from web_forms.utils.emails import send_usage_limit_reached_email
 
+from .fields import SemicolonSeparatedEmailField
+
 
 class SubmissionSerializer(serializers.Serializer):
     access_key = serializers.CharField()
     redirect = serializers.URLField(default=settings.SUBMISSION_SUCCESS_URL)
     from_name = serializers.CharField(required=False)
     reply_to = serializers.EmailField(required=False)
+    cc_emails = SemicolonSeparatedEmailField(required=False, write_only=True)
     data = serializers.JSONField(required=False)
 
     def validate_access_key(self, value):

--- a/web_forms/submissions/api/views.py
+++ b/web_forms/submissions/api/views.py
@@ -34,8 +34,7 @@ class SubmissionView(APIView):
 
     def handle_valid_submission(self, serializer):
         access_key = serializer.validated_data["access_key"]
-        data = serializer.validated_data["data"]
-        send_submission_email(access_key, data)
+        send_submission_email(access_key, serializer.validated_data)
         access_key.use_access_key()
 
 

--- a/web_forms/utils/emails.py
+++ b/web_forms/utils/emails.py
@@ -9,6 +9,7 @@ SKIP_FIELDS = [
     "access_key",
     "from_name",
     "reply_to",
+    "cc_emails",
     HONEYPOT_FIELD,
 ]
 
@@ -38,7 +39,8 @@ def format_dict_for_email(data_dict):
     return "\n".join(formatted_text)
 
 
-def send_submission_email(access_key, data):
+def send_submission_email(access_key, validated_data):
+    data = validated_data["data"]
     if "subject" in data:
         subject = data["subject"]
     else:
@@ -59,14 +61,24 @@ def send_submission_email(access_key, data):
     recipient_list = [access_key.user.email]
 
     from_email = settings.DEFAULT_FROM_EMAIL
-    from_name = data.get("from_name")
+    from_name = validated_data.get("from_name")
     if from_name:
         from_email = f"{from_name} <{settings.DEFAULT_FROM_EMAIL_ADDR}>"
 
-    reply_to = [data.get("reply_to")] if data.get("reply_to") else None
+    reply_to = (
+        [validated_data.get("reply_to")] if validated_data.get("reply_to") else None
+    )
+
+    cc_emails = validated_data.get("cc_emails", [])
+    print("DUPA:", cc_emails)
 
     msg = EmailMultiAlternatives(
-        subject, text_content, from_email, recipient_list, reply_to=reply_to
+        subject,
+        text_content,
+        from_email,
+        recipient_list,
+        reply_to=reply_to,
+        cc=cc_emails,
     )
     msg.attach_alternative(html_content, "text/html")
     msg.send(fail_silently=False)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a custom field `SemicolonSeparatedEmailField` to handle semicolon-separated email addresses in forms.
  - Added `cc_emails` field to submission forms, allowing users to include CC email addresses.

- **Bug Fixes**
  - Improved email handling in submission forms by passing the entire validated data to the email sending function.

- **Tests**
  - Added test cases for the new `SemicolonSeparatedEmailField`.
  - Updated tests to include the `cc_emails` field in submission data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->